### PR TITLE
Note Title Determination

### DIFF
--- a/TakeItEasy/Controller/Notes/NoteEditorViewController.swift
+++ b/TakeItEasy/Controller/Notes/NoteEditorViewController.swift
@@ -11,7 +11,7 @@ class NoteEditorViewController: UIViewController {
 
     @IBOutlet weak var notificationLabel: UILabel!
     @IBOutlet weak var noteBodyTextView: UITextView!
-    @IBOutlet weak var noteTitleTextField: UITextField!
+    //@IBOutlet weak var noteTitleTextField: UITextField!
     
     // Enough to use selectedNote to check edit mode
     var selectedNote : StoredNote?
@@ -32,14 +32,23 @@ class NoteEditorViewController: UIViewController {
     
     func setTextFieldContents(){
         if selectedNote != nil {
-            noteTitleTextField.text = selectedNote?.name
+            //noteTitleTextField.text = selectedNote?.name
             noteBodyTextView.text = selectedNote?.text
         }
+    }
+    
+    func getNoteTitle() -> String? {
+        let noteText = noteBodyTextView.text
+        let title = noteText?.components(separatedBy: "\n").first
+        return title
     }
 
     // Note: Won't save when closing the app from this screen, may need to be fixed.
     override func viewWillDisappear(_ animated : Bool) {
-        let noteName = noteTitleTextField.text
+        //let noteName = noteTitleTextField.text
+        //temp
+        let noteName : String? = getNoteTitle()
+        //
         let noteText = noteBodyTextView.text
         let modifiedDate = Date()
 
@@ -61,22 +70,4 @@ class NoteEditorViewController: UIViewController {
         CoreManager.saveContext()
 
     }
-    
-    /*@IBAction func saveButtonPressed(_ sender: Any) {
-        let newNoteName = noteTitleTextField.text
-        let newNoteText = noteBodyTextView.text
-        let modifiedDate = Date()
-        
-        if(newNoteName == "") {
-            print("Note name or note text fields are empty")
-            notificationLabel.textColor = .red
-            notificationLabel.text = "Note title cannot be empty"
-            //Does is need to not be empty?
-            return
-        } else {
-            let newNote = NoteManager.shared.createNote(name: newNoteName!, text: newNoteText!, modifiedDate: modifiedDate)
-            updateNoteSetWithNote(newNote: newNote)
-            navigationController?.popViewController(animated: true)
-        }
-    }*/
 }

--- a/TakeItEasy/Controller/Notes/NotesTableViewCellController.swift
+++ b/TakeItEasy/Controller/Notes/NotesTableViewCellController.swift
@@ -15,11 +15,14 @@ class NotesTableViewCellController: UITableViewCell {
     override func awakeFromNib() {
         super.awakeFromNib()
         // Initialization code
+        noteBody.numberOfLines = 3
+        noteBody.lineBreakMode = .byWordWrapping
     }
     
     func setCellTheme() {
         noteBody.textColor = .gray
         noteTitle.textColor = ThemeManager.lightTheme.boldText
+       
     }
 
     override func setSelected(_ selected: Bool, animated: Bool) {

--- a/TakeItEasy/Controller/Notes/NotesViewController.swift
+++ b/TakeItEasy/Controller/Notes/NotesViewController.swift
@@ -106,7 +106,7 @@ class NotesViewController:  UIViewController, UITableViewDelegate, UITableViewDa
     
     ///heightForRowAt
     func tableView(_ tableView: UITableView, heightForRowAt indexPath: IndexPath) -> CGFloat {
-        return 80
+        return 103
 
     }
     

--- a/TakeItEasy/Model/NoteManager.swift
+++ b/TakeItEasy/Model/NoteManager.swift
@@ -29,11 +29,4 @@ class NoteManager {
         UserManager.currentUser?.removeFromNoteSet(note)
         print("Note Deleted")
     }
-
-    // Do not use this function, this is terribly inefficient
-    func updateNote(oldNote : StoredNote, newNote : StoredNote) {
-        removeNoteFromCurrentUser(note: oldNote)
-        addNoteToCurrentUser(noteToAdd: newNote)
-        CoreManager.saveContext()
-    }
 }

--- a/TakeItEasy/View/Notes/NotesStoryboard.storyboard
+++ b/TakeItEasy/View/Notes/NotesStoryboard.storyboard
@@ -39,8 +39,8 @@
                                                     <nil key="textColor"/>
                                                     <nil key="highlightedColor"/>
                                                 </label>
-                                                <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Note body preview" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="ck5-Ov-6bZ">
-                                                    <rect key="frame" x="25" y="42" width="294.66666666666669" height="21"/>
+                                                <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" misplaced="YES" text="Note body preview" textAlignment="natural" lineBreakMode="wordWrap" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="ck5-Ov-6bZ">
+                                                    <rect key="frame" x="25" y="32" width="295" height="85"/>
                                                     <fontDescription key="fontDescription" type="system" pointSize="17"/>
                                                     <color key="textColor" white="0.66666666669999997" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
                                                     <nil key="highlightedColor"/>
@@ -106,19 +106,17 @@
                         <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
                         <subviews>
                             <textView clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="scaleToFill" textAlignment="natural" translatesAutoresizingMaskIntoConstraints="NO" id="iSw-gl-G7I">
-                                <rect key="frame" x="30" y="133" width="333" height="554"/>
-                                <color key="backgroundColor" systemColor="systemBackgroundColor"/>
+                                <rect key="frame" x="30" y="89" width="333" height="600"/>
+                                <constraints>
+                                    <constraint firstAttribute="height" relation="greaterThanOrEqual" constant="600" id="c6k-BQ-jnt"/>
+                                    <constraint firstAttribute="width" constant="333" id="piM-jc-7Zw"/>
+                                </constraints>
                                 <color key="textColor" systemColor="labelColor"/>
                                 <fontDescription key="fontDescription" type="system" pointSize="14"/>
                                 <textInputTraits key="textInputTraits" autocapitalizationType="sentences"/>
                             </textView>
-                            <textField opaque="NO" contentMode="scaleToFill" horizontalHuggingPriority="248" contentHorizontalAlignment="left" contentVerticalAlignment="center" borderStyle="roundedRect" placeholder="Note Title" textAlignment="natural" minimumFontSize="17" translatesAutoresizingMaskIntoConstraints="NO" id="6YO-Ep-GSE">
-                                <rect key="frame" x="30" y="89" width="333" height="34"/>
-                                <fontDescription key="fontDescription" type="system" pointSize="14"/>
-                                <textInputTraits key="textInputTraits"/>
-                            </textField>
                             <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Notifaction Label" textAlignment="center" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="gch-CB-Yo4">
-                                <rect key="frame" x="132" y="697" width="129.33333333333337" height="21"/>
+                                <rect key="frame" x="132" y="699" width="129.33333333333337" height="19"/>
                                 <fontDescription key="fontDescription" type="system" pointSize="17"/>
                                 <nil key="textColor"/>
                                 <nil key="highlightedColor"/>
@@ -127,21 +125,16 @@
                         <viewLayoutGuide key="safeArea" id="ddb-Rg-ueZ"/>
                         <color key="backgroundColor" systemColor="systemBackgroundColor"/>
                         <constraints>
-                            <constraint firstItem="iSw-gl-G7I" firstAttribute="width" secondItem="6YO-Ep-GSE" secondAttribute="width" id="2qi-ea-4li"/>
                             <constraint firstItem="ddb-Rg-ueZ" firstAttribute="bottom" secondItem="gch-CB-Yo4" secondAttribute="bottom" constant="100" id="4rS-MI-kHH"/>
-                            <constraint firstItem="6YO-Ep-GSE" firstAttribute="centerX" secondItem="ddb-Rg-ueZ" secondAttribute="centerX" id="Bin-o6-RCr"/>
                             <constraint firstItem="gch-CB-Yo4" firstAttribute="top" secondItem="iSw-gl-G7I" secondAttribute="bottom" constant="10" id="DJH-2x-bH3"/>
+                            <constraint firstItem="iSw-gl-G7I" firstAttribute="top" secondItem="ddb-Rg-ueZ" secondAttribute="top" constant="30" id="KWr-30-Ib9"/>
                             <constraint firstItem="gch-CB-Yo4" firstAttribute="centerX" secondItem="ddb-Rg-ueZ" secondAttribute="centerX" id="QEp-By-Reb"/>
                             <constraint firstItem="iSw-gl-G7I" firstAttribute="centerX" secondItem="ddb-Rg-ueZ" secondAttribute="centerX" id="SUF-Jw-I7K"/>
-                            <constraint firstItem="6YO-Ep-GSE" firstAttribute="leading" secondItem="ddb-Rg-ueZ" secondAttribute="leading" constant="30" id="Wfg-as-GGv"/>
-                            <constraint firstItem="iSw-gl-G7I" firstAttribute="top" secondItem="6YO-Ep-GSE" secondAttribute="bottom" constant="10" id="omc-Uk-5aF"/>
-                            <constraint firstItem="6YO-Ep-GSE" firstAttribute="top" secondItem="ddb-Rg-ueZ" secondAttribute="top" constant="30" id="qFx-rI-YWp"/>
                         </constraints>
                     </view>
                     <navigationItem key="navigationItem" id="6hR-Qz-qNX"/>
                     <connections>
                         <outlet property="noteBodyTextView" destination="iSw-gl-G7I" id="hYy-yV-dD8"/>
-                        <outlet property="noteTitleTextField" destination="6YO-Ep-GSE" id="0MI-sd-oGQ"/>
                         <outlet property="notificationLabel" destination="gch-CB-Yo4" id="sNT-eA-6fc"/>
                     </connections>
                 </viewController>


### PR DESCRIPTION
Changed how note titels are determiend. Rather than being specified by the user they are now pulled from the first line of the note. This may have to be changed as the first line of the note could by too long for a title.

Also removed some unnecessary code from noteManger, some comments, and removed the title text field.

The UI may be subject to further changes but for now, the note cells have been made large to be able to display multi-line text previews 