### PR TITLE
Fixed the note search bug

### DIFF
--- a/TakeItEasy/Controller/Notes/NotesViewController.swift
+++ b/TakeItEasy/Controller/Notes/NotesViewController.swift
@@ -121,16 +121,12 @@ class NotesViewController:  UIViewController, UITableViewDelegate, UITableViewDa
     func searchBar(_ searchBar: UISearchBar, textDidChange searchText: String) {
         var temporaryArray : [StoredNote] = []
         
-        if (noteData.isEmpty) {
-            return
-        }
-        
         if (searchText == "") {
             reloadFromCoreData()
             return
         }
         
-        //seraches by title
+        //searches by title
         for note in noteData {
             let noteName = note.name!.lowercased()
             if noteName.contains(searchText.lowercased()) {
@@ -151,51 +147,14 @@ class NotesViewController:  UIViewController, UITableViewDelegate, UITableViewDa
         
         noteData = temporaryArray
         tableView.reloadData()
+        refreshSearchPool()
     }
     
-    /*
-    // Override to support conditional editing of the table view.
-    override func tableView(_ tableView: UITableView, canEditRowAt indexPath: IndexPath) -> Bool {
-        // Return false if you do not want the specified item to be editable.
-        return true
+    func refreshSearchPool() {
+        let notesFromCoreData = UserManager.getNoteList()
+        if  notesFromCoreData != nil {
+            noteData = UserManager.getNoteList()!
+        }
+        sortNotesByRecentcy()
     }
-    */
-
-    /*
-    // Override to support editing the table view.
-    override func tableView(_ tableView: UITableView, commit editingStyle: UITableViewCell.EditingStyle, forRowAt indexPath: IndexPath) {
-        if editingStyle == .delete {
-            // Delete the row from the data source
-            tableView.deleteRows(at: [indexPath], with: .fade)
-        } else if editingStyle == .insert {
-            // Create a new instance of the appropriate class, insert it into the array, and add a new row to the table view
-        }    
-    }
-    */
-
-    /*
-    // Override to support rearranging the table view.
-    override func tableView(_ tableView: UITableView, moveRowAt fromIndexPath: IndexPath, to: IndexPath) {
-
-    }
-    */
-
-    /*
-    // Override to support conditional rearranging of the table view.
-    override func tableView(_ tableView: UITableView, canMoveRowAt indexPath: IndexPath) -> Bool {
-        // Return false if you do not want the item to be re-orderable.
-        return true
-    }
-    */
-
-    /*
-    // MARK: - Navigation
-
-    // In a storyboard-based application, you will often want to do a little preparation before navigation
-    override func prepare(for segue: UIStoryboardSegue, sender: Any?) {
-        // Get the new view controller using segue.destination.
-        // Pass the selected object to the new view controller.
-    }
-    */
-
 }


### PR DESCRIPTION
The list of notes was losing elements after every search until it was eventually empty, which would cause every subsequent search to fail. Now the notes are refreshed at the end of every search to prevent this.

Also removed a bunch of unneeded comments.

closes #53 